### PR TITLE
Update ok-sync-arm.sh

### DIFF
--- a/linux-debian/ok-sync-arm.sh
+++ b/linux-debian/ok-sync-arm.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 
+echo "We will create a folder and mount the USB"
+mkdir /mnt/ntfs
+mount /dev/sda1 /mnt/ntfs
+
 echo "initializing Okcash First time Sync"
 
 date
 
 OKUSER=$USER
 HOMEDIR="/home/$OKUSER"
-OKCASHPATH="$HOMEDIR/.okcash"
+OKCASHPATH="/mnt/ntfs"
+OKDEFAULT="$HOMEDIR/.okcash
 
 echo "User: $OKUSER"
 echo "User home dir: $HOMEDIR"
@@ -36,6 +41,10 @@ rpcp=$(pwgen -ncsB 75 1)
 echo "rpcuser=$rpcu
 rpcpassword=$rpcp
 daemon=1" > "$OKCASHPATH"/okcash.conf
+
+#Adds okcash.conf to default derectory and gives new $OKCASHPATH
+touch $OKDEFAULT/okcash.conf
+echo datadir=$OKCASHPATH > $OKDEFAULT/okcash.conf
 
 # Delete the downloaded blockchain zip file // free space from device
 rm $OKCASHPATH/ok-blockchain-arm.zip


### PR DESCRIPTION
Mount usb to a specific directory "/mnt/ntfs" and use it as $OKCASHPATH

Add a variable $OKDEFAULT for the default OKCash default directory

creates the file "okcash.conf" in $OKDEFAULT and add "datadir=$OKCASHPATH" to it (so that the first time you open the wallet it goes directly to the USB)